### PR TITLE
feat(components): add size props sm and md for textfield

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@eslint/compat": "^1.2.3",
     "@eslint/js": "9.14.0",
     "@fit-hub-indonesia/eslint": "1.5.0",
+    "@rollup/plugin-alias": "^5.1.1",
     "@rollup/plugin-commonjs": "^28.0.2",
     "@rollup/plugin-node-resolve": "^16.0.0",
     "@rollup/plugin-replace": "^6.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,7 +32,10 @@ importers:
         version: 9.14.0
       '@fit-hub-indonesia/eslint':
         specifier: 1.5.0
-        version: 1.5.0(2hc5k4tpmw3wswtcosvqppt3iy)
+        version: 1.5.0(278ef044aefa8ce299aabd21298f0f15)
+      '@rollup/plugin-alias':
+        specifier: ^5.1.1
+        version: 5.1.1(rollup@4.27.2)
       '@rollup/plugin-commonjs':
         specifier: ^28.0.2
         version: 28.0.2(rollup@4.27.2)
@@ -1004,6 +1007,15 @@ packages:
   '@pkgr/core@0.1.1':
     resolution: {integrity: sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@rollup/plugin-alias@5.1.1':
+    resolution: {integrity: sha512-PR9zDb+rOzkRb2VD+EuKB7UC41vU5DIwZ5qqCpk0KJudcWAyi8rvYOhS7+L5aZCspw1stTViLgN5v6FF1p5cgQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
 
   '@rollup/plugin-commonjs@28.0.2':
     resolution: {integrity: sha512-BEFI2EDqzl+vA1rl97IDRZ61AIwGH093d9nz8+dThxJNH8oSoB7MjWvPCX3dkaK1/RCJ/1v/R1XB15FuSs0fQw==}
@@ -5150,7 +5162,7 @@ snapshots:
 
   '@fastify/deepmerge@2.0.1': {}
 
-  '@fit-hub-indonesia/eslint@1.5.0(2hc5k4tpmw3wswtcosvqppt3iy)':
+  '@fit-hub-indonesia/eslint@1.5.0(278ef044aefa8ce299aabd21298f0f15)':
     dependencies:
       '@eslint/compat': 1.2.3(eslint@9.14.0(jiti@1.21.6))
       '@eslint/js': 9.14.0
@@ -5459,6 +5471,10 @@ snapshots:
     optional: true
 
   '@pkgr/core@0.1.1': {}
+
+  '@rollup/plugin-alias@5.1.1(rollup@4.27.2)':
+    optionalDependencies:
+      rollup: 4.27.2
 
   '@rollup/plugin-commonjs@28.0.2(rollup@4.27.2)':
     dependencies:

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -8,7 +8,6 @@ import peerDepsExternal from 'rollup-plugin-peer-deps-external';
 import postcss from 'rollup-plugin-postcss';
 import { swc } from 'rollup-plugin-swc3';
 
-
 const inputDir = 'src';
 const outputDir = 'dist';
 const baseDir = path.resolve(__dirname, './');
@@ -155,8 +154,8 @@ export default [
     plugins: [
       peerDepsExternal({ includeDependencies: true }),
       replace({
-        'import * as styles from': 'import styles from',
-        'import * as style from': 'import style from'
+        'import * as style from': 'import style from',
+        'import * as styles from': 'import styles from'
       }),
       postcss({
         autoModules: false,
@@ -166,7 +165,7 @@ export default [
           generateScopedName: '[hash:base64:9]'
         },
         namedExports: true,
-        use: ['sass']
+        use: [['sass', { includePaths: [path.resolve(__dirname, 'src')] }]]
       }),
       resolve({
         mainFields: ['module', 'main']

--- a/src/components/Banner/style.module.scss
+++ b/src/components/Banner/style.module.scss
@@ -1,8 +1,8 @@
 @use "sass:map";
 
-@use "../../styles/variables" as var;
+@use "styles/variables" as var;
 
-@use "../../styles/function" as func;
+@use "styles/function" as func;
 
 $banner-theme: (
   neutral: (

--- a/src/components/BottomNavigation/style.module.scss
+++ b/src/components/BottomNavigation/style.module.scss
@@ -1,6 +1,6 @@
-@use "../../styles/variables" as var;
+@use "styles/variables" as var;
 
-@use "../../styles/mixin" as mixin;
+@use "styles/mixin" as mixin;
 
 .bottom-navigation {
   background-color: var(--WHITE);

--- a/src/components/BottomSheet/style.module.scss
+++ b/src/components/BottomSheet/style.module.scss
@@ -1,8 +1,8 @@
 @use "sass:map";
 
-@use "../../styles/variables" as var;
+@use "styles/variables" as var;
 
-@use "../../styles/animation/keyframe-slide";
+@use "styles/animation/keyframe-slide";
 
 .bottom-sheet {
   align-items: flex-end;

--- a/src/components/Button/style.module.scss
+++ b/src/components/Button/style.module.scss
@@ -1,10 +1,10 @@
 @use "sass:map";
 
-@use "../../styles/variables" as var;
+@use "styles/variables" as var;
 
-@use "../../styles/function" as func;
+@use "styles/function" as func;
 
-@use "../../styles/mixin" as mixin;
+@use "styles/mixin" as mixin;
 
 $button-theme: (
   fill: (

--- a/src/components/ButtonIcon/style.module.scss
+++ b/src/components/ButtonIcon/style.module.scss
@@ -1,10 +1,10 @@
 @use "sass:map";
 
-@use "../../styles/function" as func;
+@use "styles/function" as func;
 
-@use "../../styles/variables" as var;
+@use "styles/variables" as var;
 
-@use "../../styles/mixin" as mixin;
+@use "styles/mixin" as mixin;
 
 $button-icon-theme: (
   "transparent": (

--- a/src/components/ButtonOnboarding/style.module.scss
+++ b/src/components/ButtonOnboarding/style.module.scss
@@ -1,8 +1,8 @@
 @use "sass:map";
 
-@use "../../styles/variables" as var;
+@use "styles/variables" as var;
 
-@use "../../styles/mixin" as mixin;
+@use "styles/mixin" as mixin;
 
 .button-onboarding {
   align-items: center;

--- a/src/components/Calendar/style.module.scss
+++ b/src/components/Calendar/style.module.scss
@@ -1,4 +1,4 @@
-@use "../../styles/variables" as var;
+@use "styles/variables" as var;
 
 .calendar {
   max-width: 700px;

--- a/src/components/Card/style.module.scss
+++ b/src/components/Card/style.module.scss
@@ -1,4 +1,4 @@
-@use "../../styles/variables" as var;
+@use "styles/variables" as var;
 
 .card {
   overflow: hidden;

--- a/src/components/Chip/index.ts
+++ b/src/components/Chip/index.ts
@@ -1,1 +1,0 @@
-export { default } from './Chip';

--- a/src/components/ChipActionable/ChipActionable.tsx
+++ b/src/components/ChipActionable/ChipActionable.tsx
@@ -1,4 +1,4 @@
-import type { HTMLAttributes } from 'react';
+import { type ButtonHTMLAttributes } from 'react';
 
 import Icon from '@/components/Icon';
 import Typography from '@/components/Typography';
@@ -9,14 +9,16 @@ import type { GenericHTMLProps } from '@/types/react';
 
 import * as styles from './style.module.scss';
 
-type ChipHTMLProps = GenericHTMLProps<HTMLAttributes<HTMLElement>>;
+type ChipActionableHTMLProps = GenericHTMLProps<
+  ButtonHTMLAttributes<HTMLButtonElement>
+>;
 
-interface ChipProps extends ChipHTMLProps {
+interface ChipActionableProps extends ChipActionableHTMLProps {
   /**
-   * Determines whether the chip is clickable.
-   * When set to `true`, the chip can be interacted with like a button.
+   * Test identifier used for testing purposes.
+   * This attribute helps identify the element during testing.
    */
-  clickable?: boolean;
+  'data-testid'?: string;
 
   /**
    * Indicates whether the chip is disabled.
@@ -37,12 +39,12 @@ interface ChipProps extends ChipHTMLProps {
   selected?: boolean;
 }
 
-const Chip = (props: ChipProps) => {
+const ChipActionable = (props: ChipActionableProps) => {
   const {
-    'aria-label': ariaLabel = 'chip',
+    'aria-label': ariaLabel = 'chip actionable',
     children,
     className,
-    clickable,
+    'data-testid': dataTestId = 'chip-actionable',
     disabled,
     icon,
     selected,
@@ -50,15 +52,14 @@ const Chip = (props: ChipProps) => {
   } = props;
 
   return (
-    <section
+    <button
       {...res}
       aria-label={ariaLabel}
       className={cx(styles['chip'], className)}
       data-disabled={disabled}
       data-selected={selected}
-      data-clickable={clickable}
       data-icon={Boolean(icon)}
-      role={clickable ? 'button' : 'presentation'}
+      data-testid={dataTestId}
     >
       {icon && <Icon className={styles['chip-icon']} icon={icon} size={16} />}
 
@@ -70,8 +71,8 @@ const Chip = (props: ChipProps) => {
       >
         {children}
       </Typography>
-    </section>
+    </button>
   );
 };
 
-export default Chip;
+export default ChipActionable;

--- a/src/components/ChipActionable/index.ts
+++ b/src/components/ChipActionable/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ChipActionable';

--- a/src/components/ChipActionable/stories/ChipActionable.stories.tsx
+++ b/src/components/ChipActionable/stories/ChipActionable.stories.tsx
@@ -1,0 +1,78 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import ChipActionable from '@/components/ChipActionable';
+
+const meta = {
+  component: ChipActionable,
+  parameters: {
+    'component-name': 'ChipActionable',
+    docs: {},
+    'import-path': '@cashbound-id/design-system/chip-actionable',
+    'source-code': 'src/components/ChipActionable'
+  },
+  title: 'Data Display/Chip/Actionable'
+} satisfies Meta<typeof ChipActionable>;
+
+export default meta;
+
+type Story = StoryObj<typeof ChipActionable>;
+
+export const Basic: Story = {
+  args: {
+    children: 'Label Text',
+    icon: 'shape-category-fill'
+  },
+  name: 'Basic Usage',
+  parameters: {
+    docs: {
+      description: {
+        story: 'This example demonstrates how to use the Button component'
+      }
+    }
+  }
+};
+
+export const ChipWithoutIcon: Story = {
+  args: {
+    children: 'Label Text'
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'You can customize the chip layout to exclude the icon if you prefer not to include it within the chip section.'
+      }
+    }
+  }
+};
+
+export const SelectedChip: Story = {
+  args: {
+    children: 'Label Text',
+    icon: 'shape-category-fill',
+    selected: true
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'You can adding flag if chip has been selected by user with defined props selected is true'
+      }
+    }
+  }
+};
+
+export const SelectedDisabled: Story = {
+  args: {
+    children: 'Label Text',
+    disabled: true,
+    icon: 'shape-category-fill'
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'You can adding flag if chip is disabled'
+      }
+    }
+  }
+};

--- a/src/components/ChipActionable/style.module.scss
+++ b/src/components/ChipActionable/style.module.scss
@@ -1,8 +1,8 @@
 @use "sass:map";
 
-@use "../../styles/function" as func;
+@use "styles/function" as func;
 
-@use "../../styles/variables" as var;
+@use "styles/variables" as var;
 
 $chip-theme: (
   init: (
@@ -15,31 +15,31 @@ $chip-theme: (
     text-color: var(--GRAYMAUVE1200),
     icon-color: var(--GRAYMAUVE1200),
     background-color: var(--VIOLET200),
-    border-color: var(--VIOLET400)
+    border-color: var(--VIOLET400),
   ),
   focus: (
     text-color: var(--GRAYMAUVE1100),
     icon-color: var(--GRAYMAUVE1100),
     background-color: var(--WHITE),
-    border-color: var(--GRAYMAUVE300)
+    border-color: var(--GRAYMAUVE300),
   ),
   active: (
     text-color: var(--GRAYMAUVE1200),
     icon-color: var(--GRAYMAUVE1200),
     background-color: var(--VIOLET300),
-    border-color: var(--VIOLET500)
+    border-color: var(--VIOLET500),
   ),
   selected: (
     text-color: var(--GRAYMAUVE1200),
     icon-color: var(--GRAYMAUVE1200),
     background-color: var(--WHITE),
-    border-color: var(--VIOLET800)
+    border-color: var(--VIOLET800),
   ),
   disabled: (
     text-color: rgb(0 0 0 / 30%),
     icon-color: rgb(0 0 0 / 30%),
     background-color: var(--GRAYMAUVE500),
-    border-color: var(--GRAYMAUVE700)
+    border-color: var(--GRAYMAUVE700),
   ),
 );
 
@@ -49,15 +49,12 @@ $chip-theme: (
   border: 1px solid;
   border-color: func.get-attribute($chip-theme, init, border-color);
   border-radius: 24px;
+  cursor: pointer;
   display: flex;
   gap: 8px;
   padding: 6px 12px;
   transition: all var.$transition-duration var.$transition-timing-fn;
   width: fit-content;
-
-  &[data-clickable="true"]:not([data-disabled="true"], [data-selected="true"]) {
-    cursor: pointer;
-  }
 
   &[data-icon="true"] {
     border-radius: 24px;
@@ -78,7 +75,12 @@ $chip-theme: (
   }
 
   &[data-selected="true"] {
-    background-color: func.get-attribute($chip-theme, selected, background-color);
+    background-color:
+      func.get-attribute(
+        $chip-theme,
+        selected,
+        background-color
+      );
     border-color: func.get-attribute($chip-theme, selected, border-color);
 
     .chip-text {
@@ -91,7 +93,12 @@ $chip-theme: (
   }
 
   &[data-disabled="true"] {
-    background-color: func.get-attribute($chip-theme, disabled, background-color);
+    background-color:
+      func.get-attribute(
+        $chip-theme,
+        disabled,
+        background-color
+      );
     border-color: func.get-attribute($chip-theme, disabled, border-color);
 
     .chip-text {
@@ -105,8 +112,13 @@ $chip-theme: (
 
   &:hover {
 
-    &:not([data-disabled="true"], [data-selected="true"]):is([data-clickable="true"]) {
-      background-color: func.get-attribute($chip-theme, hover, background-color);
+    &:not([data-disabled="true"], [data-selected="true"]) {
+      background-color:
+        func.get-attribute(
+          $chip-theme,
+          hover,
+          background-color
+        );
       border-color: func.get-attribute($chip-theme, hover, border-color);
 
       .chip-text {
@@ -121,8 +133,13 @@ $chip-theme: (
 
   &:focus {
 
-    &:not([data-disabled="true"], [data-selected="true"]):is([data-clickable="true"]) {
-      background-color: func.get-attribute($chip-theme, focus, background-color);
+    &:not([data-disabled="true"], [data-selected="true"]) {
+      background-color:
+        func.get-attribute(
+          $chip-theme,
+          focus,
+          background-color
+        );
       border-color: func.get-attribute($chip-theme, focus, border-color);
 
       .chip-text {
@@ -137,8 +154,14 @@ $chip-theme: (
 
   &:active {
 
-    &:not([data-disabled="true"], [data-selected="true"]):is([data-clickable="true"]) {
-      background-color: func.get-attribute($chip-theme, active, background-color);
+    &:not([data-disabled="true"], [data-selected="true"]):is(
+    [data-clickable="true"]) {
+      background-color:
+        func.get-attribute(
+          $chip-theme,
+          active,
+          background-color
+        );
       border-color: func.get-attribute($chip-theme, active, border-color);
 
       .chip-text {

--- a/src/components/ChipInfo/ChipInfo.tsx
+++ b/src/components/ChipInfo/ChipInfo.tsx
@@ -1,0 +1,80 @@
+import { type HTMLAttributes } from 'react';
+
+import Icon from '@/components/Icon';
+import Typography from '@/components/Typography';
+
+import { cx } from '@/utils/css';
+import type { CashboundIconType } from '@/types/icon';
+import type { GenericHTMLProps } from '@/types/react';
+
+import { CHIP_TYPE } from './constant';
+import * as styles from './style.module.scss';
+
+type ChipInfoHTMLProps = GenericHTMLProps<HTMLAttributes<HTMLElement>>;
+
+interface ChipInfoProps extends ChipInfoHTMLProps {
+  /**
+   * Test identifier used for testing purposes.
+   * This attribute helps identify the element during testing.
+   */
+  'data-testid'?: string;
+
+  /**
+   * Specifies the icon to display in the chip.
+   * The icon should be of type `CashboundIconType`.
+   */
+  icon?: CashboundIconType;
+
+  /**
+   * Visual style variant of the banner
+   */
+  type: 'success' | 'neutral' | 'warning' | 'error';
+}
+
+const ChipInfo = (props: ChipInfoProps) => {
+  const {
+    'aria-label': ariaLabel = 'chip info',
+    children,
+    className,
+    'data-testid': dataTestId = 'chip-info',
+    icon,
+    type = 'neutral',
+    ...res
+  } = props;
+  const color = CHIP_TYPE[type];
+
+  return (
+    <section
+      {...res}
+      aria-label={ariaLabel}
+      className={cx(styles['chip'], className)}
+      style={{
+        '--background-color': color.background,
+        '--border-color': color.border
+      }}
+      data-icon={Boolean(icon)}
+      data-testid={dataTestId}
+    >
+      {icon && (
+        <Icon
+          className={styles['chip-icon']}
+          icon={icon}
+          size={16}
+          color={color.icon}
+        />
+      )}
+
+      <Typography
+        className={styles['chip-text']}
+        modifier="body-md"
+        tag="span"
+        fontWeight="medium"
+        color={color.text}
+      >
+        {children}
+      </Typography>
+    </section>
+  );
+};
+
+export default ChipInfo;

--- a/src/components/ChipInfo/constant.ts
+++ b/src/components/ChipInfo/constant.ts
@@ -1,0 +1,47 @@
+import {
+  BLUE200,
+  BLUE700,
+  BLUE900,
+  BLUE1100,
+  GREENCASH200,
+  GREENCASH700,
+  GREENCASH900,
+  GREENCASH1100,
+  ORANGE200,
+  ORANGE700,
+  ORANGE900,
+  ORANGE1100,
+  REDTOMATO200,
+  REDTOMATO700,
+  REDTOMATO900,
+  REDTOMATO1100
+} from '@/constant/theme';
+
+import type { ColorType } from './types';
+
+export const CHIP_TYPE: Record<string, ColorType> = {
+  error: {
+    background: REDTOMATO200,
+    border: REDTOMATO700,
+    icon: REDTOMATO900,
+    text: REDTOMATO1100
+  },
+  neutral: {
+    background: BLUE200,
+    border: BLUE700,
+    icon: BLUE900,
+    text: BLUE1100
+  },
+  success: {
+    background: GREENCASH200,
+    border: GREENCASH700,
+    icon: GREENCASH900,
+    text: GREENCASH1100
+  },
+  warning: {
+    background: ORANGE200,
+    border: ORANGE700,
+    icon: ORANGE900,
+    text: ORANGE1100
+  }
+};

--- a/src/components/ChipInfo/index.ts
+++ b/src/components/ChipInfo/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ChipInfo';

--- a/src/components/ChipInfo/stories/ChipInfo.stories.tsx
+++ b/src/components/ChipInfo/stories/ChipInfo.stories.tsx
@@ -1,26 +1,25 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
-import Chip from '@/components/Chip';
+import ChipInfo from '@/components/ChipInfo';
 
 const meta = {
-  component: Chip,
+  component: ChipInfo,
   parameters: {
-    'component-name': 'Chip',
+    'component-name': 'ChipInfo',
     docs: {},
-    'import-path': '@cashbound-id/design-system/chip',
-    'source-code': 'src/components/Chip'
+    'import-path': '@cashbound-id/design-system/chip-info',
+    'source-code': 'src/components/ChipInfo'
   },
-  title: 'Data Display/Chip'
-} satisfies Meta<typeof Chip>;
+  title: 'Data Display/Chip/Info'
+} satisfies Meta<typeof ChipInfo>;
 
 export default meta;
 
-type Story = StoryObj<typeof Chip>;
+type Story = StoryObj<typeof ChipInfo>;
 
 export const Basic: Story = {
   args: {
     children: 'Label Text',
-    clickable: true,
     icon: 'shape-category-fill'
   },
   name: 'Basic Usage',
@@ -35,8 +34,7 @@ export const Basic: Story = {
 
 export const ChipWithoutIcon: Story = {
   args: {
-    children: 'Label Text',
-    clickable: true
+    children: 'Label Text'
   },
   parameters: {
     docs: {
@@ -51,9 +49,7 @@ export const ChipWithoutIcon: Story = {
 export const SelectedChip: Story = {
   args: {
     children: 'Label Text',
-    clickable: true,
-    icon: 'shape-category-fill',
-    selected: true
+    icon: 'shape-category-fill'
   },
   parameters: {
     docs: {
@@ -68,8 +64,6 @@ export const SelectedChip: Story = {
 export const SelectedDisabled: Story = {
   args: {
     children: 'Label Text',
-    clickable: true,
-    disabled: true,
     icon: 'shape-category-fill'
   },
   parameters: {

--- a/src/components/ChipInfo/style.module.scss
+++ b/src/components/ChipInfo/style.module.scss
@@ -1,0 +1,28 @@
+@use "sass:map";
+
+@use "styles/function" as func;
+
+@use "styles/variables" as var;
+
+.chip {
+  align-items: center;
+  background-color: var(--background-color);
+  border: 1px solid;
+  border-color: var(--border-color);
+  border-radius: 24px;
+  display: flex;
+  gap: 8px;
+  padding: 6px 12px;
+  transition: all var.$transition-duration var.$transition-timing-fn;
+  width: fit-content;
+
+  &[data-icon="true"] {
+    border-radius: 24px;
+    padding: 6px 16px 6px 12px;
+  }
+
+  .chip-text,
+  .chip-icon {
+    transition: all var.$transition-duration var.$transition-timing-fn;
+  }
+}

--- a/src/components/ChipInfo/types.ts
+++ b/src/components/ChipInfo/types.ts
@@ -1,0 +1,6 @@
+export interface ColorType {
+  background: string;
+  border: string;
+  icon: string;
+  text: string;
+}

--- a/src/components/EmojiPicker/style.module.scss
+++ b/src/components/EmojiPicker/style.module.scss
@@ -1,6 +1,6 @@
 @use "sass:map";
 
-@use "../../styles/variables" as var;
+@use "styles/variables" as var;
 
 .emoji-picker {
   position: relative;

--- a/src/components/Grid/style.module.scss
+++ b/src/components/Grid/style.module.scss
@@ -1,6 +1,6 @@
 @use "sass:math";
 
-@use "../../styles/variables" as var;
+@use "styles/variables" as var;
 
 .grid {
   display: block;

--- a/src/components/Images/style.module.scss
+++ b/src/components/Images/style.module.scss
@@ -1,4 +1,4 @@
-@use "../../styles/variables" as var;
+@use "styles/variables" as var;
 
 .images {
   background-color: var(--GRAYMAUVE200);

--- a/src/components/Month/style.module.scss
+++ b/src/components/Month/style.module.scss
@@ -1,6 +1,6 @@
-@use "../../styles/variables" as var;
+@use "styles/variables" as var;
 
-@use "../../styles/mixin" as mixin;
+@use "styles/mixin" as mixin;
 
 .month {
   max-width: 700px;

--- a/src/components/NavigationHeader/style.module.scss
+++ b/src/components/NavigationHeader/style.module.scss
@@ -1,6 +1,6 @@
 @use "sass:map";
 
-@use "../../styles/variables" as var;
+@use "styles/variables" as var;
 
 .navigation-header {
   align-items: center;

--- a/src/components/Shared/CalendarItem/style.module.scss
+++ b/src/components/Shared/CalendarItem/style.module.scss
@@ -1,6 +1,6 @@
-@use "../../../styles/variables" as var;
+@use "styles/variables" as var;
 
-@use "../../../styles/mixin" as mixin;
+@use "styles/mixin" as mixin;
 
 .button-calendar {
   align-items: center;

--- a/src/components/Shared/Overlay/style.module.scss
+++ b/src/components/Shared/Overlay/style.module.scss
@@ -1,6 +1,6 @@
-@use "../../../styles/variables" as var;
+@use "styles/variables" as var;
 
-@use "../../../styles/animation/keyframe-fade";
+@use "styles/animation/keyframe-fade";
 
 .overlay {
   animation-duration: 0.15s;

--- a/src/components/Snackbar/style.module.scss
+++ b/src/components/Snackbar/style.module.scss
@@ -1,12 +1,12 @@
 @use "sass:map";
 
-@use "../../styles/variables" as var;
+@use "styles/variables" as var;
 
-@use "../../styles/mixin" as mixin;
+@use "styles/mixin" as mixin;
 
-@use "../../styles/animation/keyframe-fade-up";
+@use "styles/animation/keyframe-fade-up";
 
-@use "../../styles/animation/keyframe-fade-scale";
+@use "styles/animation/keyframe-fade-scale";
 
 .snackbar {
   left: 0;

--- a/src/components/Spinner/style.module.scss
+++ b/src/components/Spinner/style.module.scss
@@ -1,8 +1,8 @@
 @use "sass:map";
 
-@use "../../styles/variables" as var;
+@use "styles/variables" as var;
 
-@use "../../styles/animation/keyframe-rotation";
+@use "styles/animation/keyframe-rotation";
 
 .spinner {
   align-items: center;

--- a/src/components/Tabs/style.module.scss
+++ b/src/components/Tabs/style.module.scss
@@ -1,8 +1,8 @@
 @use "sass:map";
 
-@use "../../styles/variables" as var;
+@use "styles/variables" as var;
 
-@use "../../styles/mixin" as mixin;
+@use "styles/mixin" as mixin;
 
 .tab {
   min-height: 46px;

--- a/src/components/Textfield/Textfield.tsx
+++ b/src/components/Textfield/Textfield.tsx
@@ -45,6 +45,7 @@ const Textfield = forwardRef<HTMLInputElement, TextfieldProps>(
       required,
       rules,
       showCounter,
+      size = 'sm',
       success,
       suffixIcon,
       suffixText,
@@ -207,6 +208,7 @@ const Textfield = forwardRef<HTMLInputElement, TextfieldProps>(
             data-error={error && !disabled}
             data-success={success && !disabled}
             data-disabled={disabled}
+            data-size={size}
           >
             <TextfieldAdditionalElement
               kind="prefix"

--- a/src/components/Textfield/stories/Textfield.stories.tsx
+++ b/src/components/Textfield/stories/Textfield.stories.tsx
@@ -32,6 +32,24 @@ export const Basic: Story = {
   }
 };
 
+export const WithSizeSmall: Story = {
+  args: {
+    label: 'Label',
+    size: 'sm',
+    value: 'hello world',
+    width: '500px'
+  }
+};
+
+export const WithSizeMedium: Story = {
+  args: {
+    label: 'Label',
+    size: 'md',
+    value: 'hello world',
+    width: '500px'
+  }
+};
+
 export const WithClearButton: Story = {
   args: {
     enableClear: true,

--- a/src/components/Textfield/style.module.scss
+++ b/src/components/Textfield/style.module.scss
@@ -1,3 +1,5 @@
+@use "sass:map";
+
 @use "../../styles/variables" as var;
 
 @use "../../styles/function" as func;
@@ -5,12 +7,29 @@
 $textfield-theme: (
   error: (
     base: var(--REDTOMATO800),
-    hover: var(--REDTOMATO1000)
+    hover: var(--REDTOMATO1000),
   ),
   success: (
     base: var(--GREENGRASS800),
-    hover: var(--GREENGRASS1000)
-  )
+    hover: var(--GREENGRASS1000),
+  ),
+);
+
+$textfield-size: (
+  md: (
+    padding: 12px 0px,
+    padding-with-pre-icon: 12px 16px 12px 12px,
+    padding-with-post-icon: 12px 12px 12px 16px,
+    height: 44px,
+    border-radius: map.get(var.$radius, md),
+  ),
+  sm: (
+    padding: 8px 0px,
+    padding-with-pre-icon: 8px 16px 8px 12px,
+    padding-with-post-icon: 8px 12px 8px 16px,
+    height: 36px,
+    border-radius: map.get(var.$radius, md),
+  ),
 );
 
 .textfield {
@@ -35,7 +54,6 @@ $textfield-theme: (
       flex-grow: 1;
       flex-shrink: 1;
       font-size: 14px;
-      height: 36px;
       outline: 0;
       padding: 0 12px;
       width: 100%;
@@ -45,7 +63,6 @@ $textfield-theme: (
       border-color: var(--VIOLET900);
 
       #{$current}__additional-element {
-
         &[data-kind="prefix"] {
           border-right-color: var(--VIOLET900);
         }
@@ -61,7 +78,6 @@ $textfield-theme: (
       border-color: var(--VIOLET900);
 
       #{$current}__additional-element {
-
         &[data-kind="prefix"] {
           border-right-color: var(--VIOLET900);
         }
@@ -77,7 +93,6 @@ $textfield-theme: (
         border-color: func.get-attribute($variant, base);
 
         #{$current}__additional-element {
-
           &[data-kind="prefix"] {
             border-right-color: func.get-attribute($variant, base);
           }
@@ -92,7 +107,6 @@ $textfield-theme: (
           border-color: func.get-attribute($variant, hover);
 
           #{$current}__additional-element {
-
             &[data-kind="prefix"] {
               border-right-color: func.get-attribute($variant, hover);
             }
@@ -103,6 +117,15 @@ $textfield-theme: (
           }
         }
       }
+
+      @each $size-name, $size in $textfield-size {
+        &[data-size="#{$size-name}"] {
+          border-radius: func.get-attribute($size, border-radius);
+          height: func.get-attribute($size, height);
+          min-height: func.get-attribute($size, height);
+          padding: func.get-attribute($size, padding);
+        }
+      }
     }
 
     &[data-disabled="true"] {
@@ -110,7 +133,6 @@ $textfield-theme: (
       border-color: var(--GRAYMAUVE600);
 
       #{$current}__additional-element {
-
         &[data-kind="prefix"] {
           border-right-color: var(--GRAYMAUVE600);
         }

--- a/src/components/Textfield/style.module.scss
+++ b/src/components/Textfield/style.module.scss
@@ -1,8 +1,8 @@
 @use "sass:map";
 
-@use "../../styles/variables" as var;
+@use "styles/variables" as var;
 
-@use "../../styles/function" as func;
+@use "styles/function" as func;
 
 $textfield-theme: (
   error: (

--- a/src/components/Textfield/style.module.scss
+++ b/src/components/Textfield/style.module.scss
@@ -14,7 +14,6 @@ $textfield-theme: (
     hover: var(--GREENGRASS1000),
   ),
 );
-
 $textfield-size: (
   md: (
     padding: 12px 0px,
@@ -63,6 +62,7 @@ $textfield-size: (
       border-color: var(--VIOLET900);
 
       #{$current}__additional-element {
+
         &[data-kind="prefix"] {
           border-right-color: var(--VIOLET900);
         }
@@ -78,6 +78,7 @@ $textfield-size: (
       border-color: var(--VIOLET900);
 
       #{$current}__additional-element {
+
         &[data-kind="prefix"] {
           border-right-color: var(--VIOLET900);
         }
@@ -93,6 +94,7 @@ $textfield-size: (
         border-color: func.get-attribute($variant, base);
 
         #{$current}__additional-element {
+
           &[data-kind="prefix"] {
             border-right-color: func.get-attribute($variant, base);
           }
@@ -107,6 +109,7 @@ $textfield-size: (
           border-color: func.get-attribute($variant, hover);
 
           #{$current}__additional-element {
+
             &[data-kind="prefix"] {
               border-right-color: func.get-attribute($variant, hover);
             }
@@ -133,6 +136,7 @@ $textfield-size: (
       border-color: var(--GRAYMAUVE600);
 
       #{$current}__additional-element {
+
         &[data-kind="prefix"] {
           border-right-color: var(--GRAYMAUVE600);
         }

--- a/src/components/Textfield/types.ts
+++ b/src/components/Textfield/types.ts
@@ -15,6 +15,8 @@ export interface TextfieldAdditionalProps {
   text?: string;
 }
 
+export type TextfieldSizeType = 'sm' | 'md';
+
 export type TextfieldProps = TextfieldHTMLProps &
   BaseInputProps & {
     /**
@@ -62,6 +64,11 @@ export type TextfieldProps = TextfieldHTMLProps &
      * @default false
      */
     showCounter?: boolean;
+
+    /**
+     * Size of the button
+     */
+    size?: TextfieldSizeType;
 
     /**
      * Element to be displayed the icon at the end of the input field.

--- a/src/components/Textfield/types.ts
+++ b/src/components/Textfield/types.ts
@@ -6,7 +6,7 @@ import type { GenericHTMLProps } from '@/types/react';
 
 type TextfieldHTMLProps = Omit<
   GenericHTMLProps<InputHTMLAttributes<HTMLInputElement>>,
-  'onChange' | 'value' | 'disabled' | 'prefix' | 'suffix'
+  'onChange' | 'value' | 'disabled' | 'prefix' | 'suffix' | 'size'
 >;
 
 export interface TextfieldAdditionalProps {

--- a/src/components/ToggleButton/style.module.scss
+++ b/src/components/ToggleButton/style.module.scss
@@ -1,6 +1,6 @@
 @use "sass:map";
 
-@use "../../styles/variables" as var;
+@use "styles/variables" as var;
 
 .toggle-button {
   background-color: var(--GRAYMAUVE300);

--- a/src/components/Tooltip/style.module.scss
+++ b/src/components/Tooltip/style.module.scss
@@ -1,8 +1,8 @@
 @use "sass:map";
 
-@use "../../styles/variables" as var;
+@use "styles/variables" as var;
 
-@use "../../styles/animation/keyframe-fade";
+@use "styles/animation/keyframe-fade";
 
 .tooltip {
   cursor: pointer;

--- a/src/components/Typography/style.module.scss
+++ b/src/components/Typography/style.module.scss
@@ -1,6 +1,6 @@
 @use "sass:map";
 
-@use "../../styles/variables" as var;
+@use "styles/variables" as var;
 
 .typography {
   display: block;

--- a/src/context/DesignSystem/style.scss
+++ b/src/context/DesignSystem/style.scss
@@ -1,4 +1,4 @@
-@use "../../styles/mixin" as mixin;
+@use "styles/mixin" as mixin;
 
 html,
 body,

--- a/src/storybook/components/CardShowcaseUI/style.module.scss
+++ b/src/storybook/components/CardShowcaseUI/style.module.scss
@@ -1,6 +1,6 @@
 @use "sass:map";
 
-@use "../../../styles/variables" as var;
+@use "styles/variables" as var;
 
 .card-showcase-ui {
   cursor: pointer;

--- a/src/storybook/main.ts
+++ b/src/storybook/main.ts
@@ -46,6 +46,7 @@ const config: StorybookConfig = {
             loader: 'sass-loader',
             options: {
               sassOptions: {
+                includePaths: [path.resolve(__dirname, '../src')],
                 outputStyle: 'compressed'
               }
             }
@@ -70,6 +71,7 @@ const config: StorybookConfig = {
             loader: 'sass-loader',
             options: {
               sassOptions: {
+                includePaths: [path.resolve(__dirname, '../src')],
                 outputStyle: 'compressed'
               }
             }
@@ -81,7 +83,8 @@ const config: StorybookConfig = {
     if (config.resolve) {
       config.resolve.alias = {
         ...config.resolve.alias,
-        '@': path.resolve(__dirname, '../')
+        '@': path.resolve(__dirname, '../'),
+        styles: path.resolve(__dirname, '../styles')
       };
       config.resolve.extensions?.push('.ts', '.tsx');
     }


### PR DESCRIPTION
## Description

adding props size for component textfield

## Screenshot

![image](https://github.com/user-attachments/assets/b7014aec-ea5a-4c7b-9a91-2da005d16f32)


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
